### PR TITLE
Add multizone base path support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from 'next';
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH !== undefined
+  ? process.env.NEXT_PUBLIC_BASE_PATH
+  : '/us/child-tax-credit-2024-election-calculator';
+
+
 const nextConfig: NextConfig = {
+  ...(basePath ? { basePath } : {}),
+  env: { NEXT_PUBLIC_BASE_PATH: basePath },
   // Mantine ships CJS interop and relies on browser globals.
   // Transpile so Next can render its components without ESM/CJS mismatch.
   transpilePackages: ['@mantine/core', '@mantine/hooks'],


### PR DESCRIPTION
Adds a production base path for the PolicyEngine multizone mount and keeps local/root builds available with `NEXT_PUBLIC_BASE_PATH=` where the app uses Next.js.

Also prefixes root-relative public data/assets where needed so the zone loads correctly behind `policyengine.org` instead of only passing a framework build.

Verification:
- `git diff --check`